### PR TITLE
feat: add 'OrderController' APIs, and rename response schema field

### DIFF
--- a/src/main/java/com/example/demo/controllers/OrderController.java
+++ b/src/main/java/com/example/demo/controllers/OrderController.java
@@ -3,17 +3,17 @@ package com.example.demo.controllers;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.catalina.connector.Response;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.example.demo.dto.CheckoutRequest;
+import com.example.demo.dto.OrderDetailInfo;
 import com.example.demo.dto.OrderInfo;
 import com.example.demo.responses.ApiResponse;
 
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 
@@ -58,6 +58,21 @@ public class OrderController {
         orderInfo.setCreatedAt(java.time.LocalDateTime.now());
         orderInfo.setUpdatedAt(java.time.LocalDateTime.now());
         ApiResponse response = new ApiResponse(Map.of("orders", orderInfo));
+        return ResponseEntity.ok(response);
+    }
+    
+    @GetMapping("/{orderId}/items")
+    public ResponseEntity<?> getOrderItems(@PathVariable Long orderId) {
+
+        OrderDetailInfo orderDetailInfo = new OrderDetailInfo();
+        orderDetailInfo.setOrderId(1L);
+        orderDetailInfo.setProductId(1L);
+        orderDetailInfo.setProductName("商品名稱");
+        orderDetailInfo.setPrice(2000L);
+        orderDetailInfo.setQuantity(2);
+        orderDetailInfo.setTotalPrice(4000L);
+
+        ApiResponse response = new ApiResponse(Map.of("items", List.of(orderDetailInfo)));
         return ResponseEntity.ok(response);
     }
     

--- a/src/main/java/com/example/demo/docs/api-spec.yaml
+++ b/src/main/java/com/example/demo/docs/api-spec.yaml
@@ -650,7 +650,7 @@ paths:
                       data:
                         type: object
                         properties:
-                          orderDetails:
+                          items:
                             type: array
                             items:
                               $ref: "#/components/schemas/OrderDetailInfo"


### PR DESCRIPTION
Summary:

**feat: add 'OrderController' APIs, and rename response schema field**
- add GET orders/{orderId}/items to retrieve order details
- rename response schema field from 'orderdetails' to 'items'