### PR TITLE
feat: Add GlobalException and ApiException to error handing

### DIFF
--- a/src/main/java/com/example/demo/exception/ApiException.java
+++ b/src/main/java/com/example/demo/exception/ApiException.java
@@ -1,0 +1,27 @@
+package com.example.demo.exception;
+
+import java.util.Map;
+
+import com.example.demo.dto.ErrorInfo;
+
+public class ApiException extends RuntimeException {
+    private static final long serialVersionUID = 1L;
+
+    private final int statusCode;
+    private final Map<String,Object> data;
+
+    public ApiException(String message, int statusCode, ErrorInfo errorInfo) {
+        super(message);
+        this.statusCode = statusCode;
+        this.data = errorInfo != null ? Map.of("errors",errorInfo.getErrors()) : null;
+    }
+
+    public int getStatusCode() {
+        return statusCode;
+    }
+
+    public Map<String, Object> getData() {
+        return data;
+    }   
+
+}

--- a/src/main/java/com/example/demo/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/demo/exception/GlobalExceptionHandler.java
@@ -1,0 +1,20 @@
+package com.example.demo.exception;
+
+import java.util.Map;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import com.example.demo.responses.ApiResponse;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(ApiException.class)
+    public ResponseEntity<ApiResponse> handleApiException(ApiException ex) {
+        ApiResponse response = new ApiResponse(ex.getData());
+
+        return ResponseEntity.status(ex.getStatusCode()).body(response);
+    }
+}


### PR DESCRIPTION
## Summary
Implement centralized error handling Exception using RestControllerAdvice.

## New Files Add
- GlobalException : Handling all API-level exceptions.
- ApiException: Custom exception class for standardized for error responses.

## Change Made

### GlobalException
- Add exception handler for `ApiException`

### ApiException
- Introduced custom fields:
- `statusCode`: HTTP status code to return
- `message`: Error description
- `data`: Optional additional error data
