### PR TITLE
feat: Add password validator, update DTO request schema and login response

### DIFF
--- a/src/main/java/com/example/demo/controllers/UserController.java
+++ b/src/main/java/com/example/demo/controllers/UserController.java
@@ -17,6 +17,8 @@ import jakarta.transaction.Transactional;
 import jakarta.validation.Valid;
 import lombok.extern.slf4j.Slf4j;
 
+import java.util.Map;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindingResult;
@@ -48,7 +50,7 @@ public class UserController {
         loginInfo.setEmail("test@gmail.com");
         loginInfo.setToken("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c");
 
-        ApiResponse response = new ApiResponse(loginInfo);
+        ApiResponse response = new ApiResponse(Map.of("user", loginInfo));
         return ResponseEntity.ok().body(response);
     }
 

--- a/src/main/java/com/example/demo/docs/api-spec.yaml
+++ b/src/main/java/com/example/demo/docs/api-spec.yaml
@@ -1167,11 +1167,15 @@ components:
       required:
         - email
         - password
+        - confirmPassword
       properties:
         email:
           type: string
           example: "Test@gmail.com"
         password:
+          type: string
+          example: Aa123456
+        confirmPassword:
           type: string
           example: Aa123456
     UpdateUserRequest:

--- a/src/main/java/com/example/demo/dto/RegisterRequest.java
+++ b/src/main/java/com/example/demo/dto/RegisterRequest.java
@@ -1,5 +1,6 @@
 package com.example.demo.dto;
 
+import com.example.demo.vaildator.PasswordMatches;
 import com.example.demo.vaildator.UniqueEmail;
 
 import jakarta.validation.constraints.Email;
@@ -7,13 +8,17 @@ import jakarta.validation.constraints.NotBlank;
 import lombok.Data;
 
 @Data
+@PasswordMatches
 public class RegisterRequest {
 
     @NotBlank(message = "信箱未輸入")
     @Email(message = "信箱格式不正確")
     @UniqueEmail
     private String email;
-
+    
     @NotBlank(message = "密碼未輸入")
     private String password;
+
+    @NotBlank(message = "確認密碼未輸入")
+    private String confirmPassword;
 }

--- a/src/main/java/com/example/demo/vaildator/PasswordMatches.java
+++ b/src/main/java/com/example/demo/vaildator/PasswordMatches.java
@@ -1,0 +1,21 @@
+package com.example.demo.vaildator;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+@Documented
+@Target({ ElementType.TYPE })
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = PasswordMatchesValidator.class)
+public @interface PasswordMatches {
+    String message() default "密碼與確認密碼不一致";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+
+}

--- a/src/main/java/com/example/demo/vaildator/PasswordMatchesValidator.java
+++ b/src/main/java/com/example/demo/vaildator/PasswordMatchesValidator.java
@@ -1,0 +1,27 @@
+package com.example.demo.vaildator;
+
+import org.springframework.stereotype.Component;
+
+import com.example.demo.dto.RegisterRequest;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+@Component
+public class PasswordMatchesValidator implements ConstraintValidator<PasswordMatches, Object>{
+
+    @Override
+    public boolean isValid(Object obj, ConstraintValidatorContext context) {
+        if (obj instanceof RegisterRequest request) {
+            boolean matched = request.getPassword().equals(request.getConfirmPassword());
+            if (!matched) {
+                context.disableDefaultConstraintViolation();
+                context.buildConstraintViolationWithTemplate("密碼與確認密碼不一致")
+                        .addPropertyNode("confirmPassword")
+                        .addConstraintViolation();
+            }
+            return matched;
+        }
+        return false;
+    }
+}


### PR DESCRIPTION
## Change Made

### Add password confirmation validator
- `PasswordMatches.java`: annotation for matching password fields
- `PasswordMatchesValidator.java`: Implement vaildation logic for `@PasswordMatches `
- `RegisterRequest.java`: Apply @PasswordMatches` to validator password and confirmpasword

### Update user login response and register schema
- `UserController.java`: Update POST `users/login` to return full user object
- `api-spec`: Add confirmpassword field to RegisterRequest schema