### PR TITLE
feat: Add forget password api and update sub-repository

### DIFF
--- a/src/main/java/com/example/demo/controllers/UserController.java
+++ b/src/main/java/com/example/demo/controllers/UserController.java
@@ -3,6 +3,7 @@ package com.example.demo.controllers;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.example.demo.dto.ForgetPasswordRequest;
 import com.example.demo.dto.LoginRequest;
 import com.example.demo.dto.RegisterRequest;
 import com.example.demo.dto.UpdatePasswordRequest;
@@ -18,6 +19,7 @@ import lombok.extern.slf4j.Slf4j;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -67,12 +69,9 @@ public class UserController {
     }
     
     @GetMapping("/me")
-    public ResponseEntity<?> getProfile() {
-        UserInfo userInfo = new UserInfo();
-        userInfo.setName("Test");
-        userInfo.setEmail("test@gmail.com");
+    public ResponseEntity<?> getProfile(@AuthenticationPrincipal Long userId) {
 
-        ApiResponse response = new ApiResponse(userInfo);
+        ApiResponse response = userService.getProfile(userId);
         return ResponseEntity.ok().body(response);
     }
     
@@ -89,6 +88,14 @@ public class UserController {
         ApiResponse response = new ApiResponse(null);
         return ResponseEntity.ok().body(response);
     }
+
+    @PostMapping("/forget-password")
+    public ResponseEntity<?> forgetPassword(@Valid @RequestBody ForgetPasswordRequest request) {
+
+        ApiResponse response =new ApiResponse(null);
+        return ResponseEntity.ok().body(response);
+    }
+    
 
     @GetMapping("/verify/{token}")
     public ResponseEntity<?> verifyEmail(@PathVariable String token) {

--- a/src/main/java/com/example/demo/dto/ForgetPasswordRequest.java
+++ b/src/main/java/com/example/demo/dto/ForgetPasswordRequest.java
@@ -1,0 +1,15 @@
+package com.example.demo.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Data;
+
+@Data
+public class ForgetPasswordRequest {
+    @NotBlank(message = "Email is required")
+    @NotNull(message = "Email cannot be null")
+    @Email(message = "Invalid email format")
+    private String email;
+
+}

--- a/src/main/java/com/example/demo/dto/UserProfileInfo.java
+++ b/src/main/java/com/example/demo/dto/UserProfileInfo.java
@@ -1,0 +1,18 @@
+package com.example.demo.dto;
+
+import java.time.LocalDate;
+
+import lombok.Data;
+
+@Data
+public class UserProfileInfo {
+    private String email;
+    private String name;
+    private String image;
+    private Byte gender;
+    private LocalDate birthday;
+    private String phone;
+    private String city;
+    private String country;
+    private String address;
+}

--- a/src/main/java/com/example/demo/services/UserService.java
+++ b/src/main/java/com/example/demo/services/UserService.java
@@ -2,17 +2,21 @@ package com.example.demo.services;
 
 import java.time.LocalDateTime;
 import java.util.Map;
+import java.util.Optional;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
 import com.example.demo.bean.UserBean;
+import com.example.demo.dto.ErrorInfo;
 import com.example.demo.dto.LoginInfo;
 import com.example.demo.dto.LoginRequest;
 import com.example.demo.dto.RegisterRequest;
 import com.example.demo.dto.UserInfo;
+import com.example.demo.dto.UserProfileInfo;
 import com.example.demo.enums.UserRole;
+import com.example.demo.exception.ApiException;
 import com.example.demo.repository.UserRepository;
 import com.example.demo.responses.ApiResponse;
 import com.example.demo.utils.JwtUtil;
@@ -73,5 +77,28 @@ public class UserService {
 
         return new ApiResponse(Map.of("user", userInfo));
 
+    }
+
+    public ApiResponse getProfile(Long userId) {
+
+        Optional<UserBean> user = userRepository.findById(userId);
+        if (user.isEmpty()) {
+            ErrorInfo errorInfo = new ErrorInfo();
+            errorInfo.addError("user", "Connection abnormal");
+            throw new ApiException("User not found", 404, errorInfo);
+        }
+
+        UserProfileInfo userInfo = new UserProfileInfo();
+        userInfo.setName(user.get().getName());
+        userInfo.setEmail(user.get().getEmail());
+        userInfo.setImage(user.get().getImage());
+        userInfo.setGender(user.get().getGender());
+        userInfo.setBirthday(user.get().getBirthday());
+        userInfo.setPhone(user.get().getPhone());
+        userInfo.setCity(user.get().getCity());
+        userInfo.setCountry(user.get().getCountry());
+        userInfo.setAddress(user.get().getAddress());
+
+        return new ApiResponse(Map.of("user", userInfo));
     }
 }


### PR DESCRIPTION
## Change Made
### Add forget password api, and service logic
- `UserController`: Add POST `/users/forget-password` endpoint
- `UserService`: Implement forget password logic
- `UserProfileInfo`: Used for responsding to user profile detail request
- `ForgetPasswordRequest`: Used for receive forget password request

### Update sub-repository ecommerce-docs
- For details, please check the commit log in that repository