### PR TITLE
feat: implement ForgetPassword logic, split user api, add DTOs and validator

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,10 @@
 			<artifactId>spring-boot-starter-validation</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-mail</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>org.springframework.security</groupId>
 			<artifactId>spring-security-crypto</artifactId>
 		</dependency>

--- a/src/main/java/com/example/demo/config/JwtFilter.java
+++ b/src/main/java/com/example/demo/config/JwtFilter.java
@@ -1,6 +1,7 @@
 package com.example.demo.config;
 
 import java.io.IOException;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -45,7 +46,7 @@ public class JwtFilter extends OncePerRequestFilter{
         } catch (ExpiredJwtException | SignatureException | MalformedJwtException e) {
             response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
             response.setContentType("application/json");
-            response.getWriter().write("{\"status\":\"error\", \"errors\":{\"token\":\"Token 無效或已過期\"}}");
+            response.getWriter().write("{\"timestamp\":\"" + LocalDateTime.now() + "\", \"data\":{\"errors\":{\"token\":\"Token is expired or invalid\"}}}");
             return;
         }
 

--- a/src/main/java/com/example/demo/config/SecurityConfig.java
+++ b/src/main/java/com/example/demo/config/SecurityConfig.java
@@ -26,6 +26,8 @@ public class SecurityConfig {
             .authorizeHttpRequests(auth -> auth
                 .requestMatchers("/users/login").permitAll()
                 .requestMatchers("/users/register").permitAll()
+                .requestMatchers("/users/forget-password").permitAll()
+                .requestMatchers("/users/verify/**").permitAll() // 允許忘記密碼驗證連結
                 .anyRequest().authenticated()
             )
             .csrf(csrf -> csrf.disable()) // 可選擇關閉 CSRF（特別是 API）

--- a/src/main/java/com/example/demo/controllers/UserController.java
+++ b/src/main/java/com/example/demo/controllers/UserController.java
@@ -1,7 +1,17 @@
 package com.example.demo.controllers;
 
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -9,6 +19,7 @@ import com.example.demo.dto.ForgetPasswordRequest;
 import com.example.demo.dto.LoginRequest;
 import com.example.demo.dto.RegisterRequest;
 import com.example.demo.dto.UpdatePasswordRequest;
+import com.example.demo.dto.UpdateUserAvatarRequqst;
 import com.example.demo.dto.UpdateUserRequest;
 import com.example.demo.responses.ApiResponse;
 import com.example.demo.services.UserService;
@@ -17,17 +28,6 @@ import com.example.demo.utils.VaildationHelper;
 import jakarta.transaction.Transactional;
 import jakarta.validation.Valid;
 import lombok.extern.slf4j.Slf4j;
-
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.validation.BindingResult;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PutMapping;
 
 @Slf4j
 @RestController
@@ -44,12 +44,9 @@ public class UserController {
      * 用戶登入
      * 
      * @Valid 用於驗證 LoginRequest 中的字段
-     * 
      * @param loginRequest
-     * 
      * @param result
-     * 
-     * @return
+     * @return 
      */
     @PostMapping("/login")
     public ResponseEntity<?> login(@Valid @RequestBody LoginRequest loginRequest, BindingResult result) {
@@ -82,10 +79,8 @@ public class UserController {
     }
 
     @PutMapping("/me")
-    public ResponseEntity<?> editProfile(@Valid @AuthenticationPrincipal Long userId,
-            @RequestPart("data") UpdateUserRequest updateUserRequest,
-            @RequestPart(value = "file", required = false) MultipartFile file,
-            BindingResult result) {
+    public ResponseEntity<?> editProfile(@Valid @AuthenticationPrincipal Long userId, BindingResult result,
+            @RequestBody UpdateUserRequest updateUserRequest) {
 
         validationHelper.validateOrThrow(result);
 
@@ -93,10 +88,21 @@ public class UserController {
         ApiResponse response = userService.editProfile(updateUserRequest);
         return ResponseEntity.ok().body(response);
     }
+    @PutMapping("/me/avatar")
+    public ResponseEntity<?> updateAvatar(@AuthenticationPrincipal Long userId ,
+            @RequestParam("file") MultipartFile file, @RequestParam("image") String image) {
+
+        UpdateUserAvatarRequqst updateUserAvatar = new UpdateUserAvatarRequqst();
+        updateUserAvatar.setUserId(userId);
+        updateUserAvatar.setFile(file);
+        updateUserAvatar.setImage(image);
+        ApiResponse response = userService.updateAvatar(updateUserAvatar);
+        return ResponseEntity.ok().body(response);
+    }
 
     @PatchMapping("/me/password")
-    public ResponseEntity<?> changePassword(@Valid @AuthenticationPrincipal Long userId,
-            @RequestBody UpdatePasswordRequest updatePasswordRequest, BindingResult result) {
+    public ResponseEntity<?> changePassword(@Valid @AuthenticationPrincipal Long userId, BindingResult result,
+            @RequestBody UpdatePasswordRequest updatePasswordRequest) {
         validationHelper.validateOrThrow(result);
 
         updatePasswordRequest.setUserId(userId);
@@ -105,9 +111,10 @@ public class UserController {
     }
 
     @PostMapping("/forget-password")
-    public ResponseEntity<?> forgetPassword(@Valid @RequestBody ForgetPasswordRequest request) {
+    public ResponseEntity<?> forgetPassword(@Valid @RequestBody ForgetPasswordRequest request, BindingResult result) {
 
-        ApiResponse response = new ApiResponse(null);
+        validationHelper.validateOrThrow(result);
+        ApiResponse response = userService.forgetPassword(request);
         return ResponseEntity.ok().body(response);
     }
 

--- a/src/main/java/com/example/demo/dto/UpdateUserAvatarRequqst.java
+++ b/src/main/java/com/example/demo/dto/UpdateUserAvatarRequqst.java
@@ -1,0 +1,21 @@
+package com.example.demo.dto;
+
+import org.springframework.web.multipart.MultipartFile;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Data;
+
+@Data
+public class UpdateUserAvatarRequqst {
+
+    @JsonIgnore
+    private MultipartFile file;
+
+    @JsonIgnore
+    private Long userId;
+
+    @NotBlank(message = "Image is required")
+    private String image;
+}

--- a/src/main/java/com/example/demo/dto/UpdateUserRequest.java
+++ b/src/main/java/com/example/demo/dto/UpdateUserRequest.java
@@ -17,10 +17,6 @@ public class UpdateUserRequest {
     @Schema(hidden = true)
     private Long userId;
 
-    @JsonIgnore
-    @Schema(hidden = true)
-    private MultipartFile file;
-
     @NotBlank(message = "Name is required")
     private String name;
     
@@ -32,10 +28,7 @@ public class UpdateUserRequest {
 
     @NotBlank(message = "phone is required")
     private String phone;
-
-    @NotBlank(message = "image is required")
-    private String image;
-
+    
     @NotBlank(message = "city is required")
     private String city;
 

--- a/src/main/java/com/example/demo/services/EmailService.java
+++ b/src/main/java/com/example/demo/services/EmailService.java
@@ -1,0 +1,20 @@
+package com.example.demo.services;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+
+@Service
+public class EmailService {
+    @Autowired
+    private JavaMailSender mailSender;
+
+    public void sendSimpleMail(String to, String subject, String text) {
+        SimpleMailMessage message = new SimpleMailMessage();
+        message.setTo(to);                       // 收件人
+        message.setSubject(subject);             // 主旨
+        message.setText(text);                   // 內容
+        mailSender.send(message);
+    }
+}

--- a/src/main/java/com/example/demo/utils/ResetTokenGenerator.java
+++ b/src/main/java/com/example/demo/utils/ResetTokenGenerator.java
@@ -1,0 +1,56 @@
+package com.example.demo.utils;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.UUID;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ResetTokenGenerator {
+
+    @Value("${app.reset-token.duration-minutes:30}")
+    private int defaultDuration;
+
+    /**
+     * 產生忘記密碼 token（預設 30 分鐘有效）
+     */
+    public ResetTokenData generate() {
+        return generate(defaultDuration);
+    }
+
+    /**
+     * 產生忘記密碼 token（可自訂有效時間）
+     *
+     * @param durationInMinutes 有效時間（分鐘）
+     */
+    public ResetTokenData generate(int durationInMinutes) {
+        String token = UUID.randomUUID().toString();
+        Instant expiresAt = Instant.now().plus(durationInMinutes, ChronoUnit.MINUTES);
+        return new ResetTokenData(token, expiresAt);
+    }
+
+    // 資料封裝類
+    public static class ResetTokenData {
+        private final String token;
+        private final Instant expiresAt;
+
+        public ResetTokenData(String token, Instant expiresAt) {
+            this.token = token;
+            this.expiresAt = expiresAt;
+        }
+
+        public String getToken() {
+            return token;
+        }
+
+        public Instant getExpiresAt() {
+            return expiresAt;
+        }
+
+        public boolean isExpired() {
+            return Instant.now().isAfter(expiresAt);
+        }
+    }
+}

--- a/src/main/java/com/example/demo/vaildator/EditProfileValidator.java
+++ b/src/main/java/com/example/demo/vaildator/EditProfileValidator.java
@@ -38,44 +38,44 @@ public class EditProfileValidator implements CustValidator<UpdateUserRequest, Us
             return new ApiException("User not found", 404, errorInfo);
         });
         
-        if(target.getFile() == null || target.getFile().isEmpty()) {
-            return user;
-        }
+        // if(target.getFile() == null || target.getFile().isEmpty()) {
+        //     return user;
+        // }
 
-        String originalFilename = target.getFile().getOriginalFilename();
-        if (originalFilename == null || originalFilename.isEmpty()) {
-            errorInfo.addError("file", "File name cannot be empty");
-        }else{
-            if (originalFilename.length() > 255) {
-                errorInfo.addError("file", "File name is too long");
-            }
+        // String originalFilename = target.getFile().getOriginalFilename();
+        // if (originalFilename == null || originalFilename.isEmpty()) {
+        //     errorInfo.addError("file", "File name cannot be empty");
+        // }else{
+        //     if (originalFilename.length() > 255) {
+        //         errorInfo.addError("file", "File name is too long");
+        //     }
 
-            String ext = originalFilename.substring(originalFilename.lastIndexOf("."));
-            if (!List.of(".jpg", ".jpeg", ".png", ".webp").contains(ext.toLowerCase())) {
-                errorInfo.addError("file", "File type must be jpg, jpeg, png, or webp");
-            }
-        }
-
-        
-        if (errorInfo.hasErrors()) {
-            throw new ApiException("Validation failed", 400, errorInfo);
-        }
-
-        String uploadDir = System.getProperty("user.dir") + "/upload/";
-        File folder = new File(uploadDir);
-        if (!folder.exists()) folder.mkdirs();
-
-        String filename = UUID.randomUUID() + "_" + target.getFile().getOriginalFilename();
-        Path path = Paths.get(uploadDir + filename);
-        try {
-            target.getFile().transferTo(path.toFile());
-        } catch (IOException e) {
-            errorInfo.addError("file", "File upload failed");
-            throw new ApiException("File upload failed", 500, errorInfo);
-        }
+        //     String ext = originalFilename.substring(originalFilename.lastIndexOf("."));
+        //     if (!List.of(".jpg", ".jpeg", ".png", ".webp").contains(ext.toLowerCase())) {
+        //         errorInfo.addError("file", "File type must be jpg, jpeg, png, or webp");
+        //     }
+        // }
 
         
-        target.setImage(filename);
+        // if (errorInfo.hasErrors()) {
+        //     throw new ApiException("Validation failed", 400, errorInfo);
+        // }
+
+        // String uploadDir = System.getProperty("user.dir") + "/upload/";
+        // File folder = new File(uploadDir);
+        // if (!folder.exists()) folder.mkdirs();
+
+        // String filename = UUID.randomUUID() + "_" + target.getFile().getOriginalFilename();
+        // Path path = Paths.get(uploadDir + filename);
+        // try {
+        //     target.getFile().transferTo(path.toFile());
+        // } catch (IOException e) {
+        //     errorInfo.addError("file", "File upload failed");
+        //     throw new ApiException("File upload failed", 500, errorInfo);
+        // }
+
+        
+        // target.setImage(filename);
         return user;
     }
 

--- a/src/main/java/com/example/demo/vaildator/ForgetPasswordValidator.java
+++ b/src/main/java/com/example/demo/vaildator/ForgetPasswordValidator.java
@@ -1,0 +1,36 @@
+package com.example.demo.vaildator;
+
+import org.springframework.stereotype.Component;
+
+import com.example.demo.bean.UserBean;
+import com.example.demo.dto.ErrorInfo;
+import com.example.demo.dto.ForgetPasswordRequest;
+import com.example.demo.exception.ApiException;
+import com.example.demo.repository.UserRepository;
+import com.example.demo.utils.JwtUtil;
+
+@Component
+public class ForgetPasswordValidator implements CustValidator<ForgetPasswordRequest,UserBean>{
+
+    private final UserRepository userRepository;
+    public ForgetPasswordValidator(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    @Override
+    public boolean support(Class<?> clazz) {
+        return ForgetPasswordRequest.class.isAssignableFrom(clazz);
+    }
+
+    @Override
+    public UserBean validate(ForgetPasswordRequest request) {
+        // Perform validation logic here
+        ErrorInfo errorInfo = new ErrorInfo();
+        UserBean user = userRepository.findByEmail(request.getEmail()).orElseThrow(() -> {
+            errorInfo.addError("email", "Email doesn't exists: " + request.getEmail());
+            throw new ApiException("Email not found", 400,errorInfo);
+        });
+        return user;
+    }
+    
+}

--- a/src/main/java/com/example/demo/vaildator/UpdateAvatarValidator.java
+++ b/src/main/java/com/example/demo/vaildator/UpdateAvatarValidator.java
@@ -1,0 +1,82 @@
+package com.example.demo.vaildator;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.stereotype.Component;
+
+import com.example.demo.bean.UserBean;
+import com.example.demo.dto.ErrorInfo;
+import com.example.demo.dto.UpdateUserAvatarRequqst;
+import com.example.demo.exception.ApiException;
+import com.example.demo.repository.UserRepository;
+
+@Component
+public class UpdateAvatarValidator implements CustValidator<UpdateUserAvatarRequqst, UserBean> {
+
+    private final UserRepository userRepository;
+
+    public UpdateAvatarValidator(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    @Override
+    public boolean support(Class<?> clazz) {
+        return UpdateUserAvatarRequqst.class.equals(clazz);
+    }
+
+    @Override
+    public UserBean validate(UpdateUserAvatarRequqst target) {
+        ErrorInfo errorInfo = new ErrorInfo();
+        UserBean user = userRepository.findById(target.getUserId())
+        .orElseThrow(() -> {
+            errorInfo.addError("userId", "Connection abnormal");
+            return new ApiException("User not found", 404, errorInfo);
+        });
+        
+        if(target.getFile() == null || target.getFile().isEmpty()) {
+            return user;
+        }
+
+        String originalFilename = target.getFile().getOriginalFilename();
+        if (originalFilename == null || originalFilename.isEmpty()) {
+            errorInfo.addError("file", "File name cannot be empty");
+        }else{
+            if (originalFilename.length() > 255) {
+                errorInfo.addError("file", "File name is too long");
+            }
+
+            String ext = originalFilename.substring(originalFilename.lastIndexOf("."));
+            if (!List.of(".jpg", ".jpeg", ".png", ".webp").contains(ext.toLowerCase())) {
+                errorInfo.addError("file", "File type must be jpg, jpeg, png, or webp");
+            }
+        }
+
+        
+        if (errorInfo.hasErrors()) {
+            throw new ApiException("Validation failed", 400, errorInfo);
+        }
+
+        String uploadDir = System.getProperty("user.dir") + "/upload/";
+        File folder = new File(uploadDir);
+        if (!folder.exists()) folder.mkdirs();
+
+        String filename = UUID.randomUUID() + "_" + target.getFile().getOriginalFilename();
+        Path path = Paths.get(uploadDir + filename);
+        try {
+            target.getFile().transferTo(path.toFile());
+        } catch (IOException e) {
+            errorInfo.addError("file", "File upload failed");
+            throw new ApiException("File upload failed", 500, errorInfo);
+        }
+
+        
+        target.setImage(filename);
+        return user;
+    }
+
+}


### PR DESCRIPTION
## Change Made
- SecurityConfig.java: add /users/forget-password and /users/verify/** requestMatchers for the user forget password validation flow
- UserController.java: 
	- remove upload image feature from editProfile API
	- functionality split into to updateAvatar
	- add forget password service logic
	- remove unused imports 
- UpdateUserRequest.java: extract image and file fields into UpdateUserAvatar
- UserService.java: 
	- editProfile upload image functionality split into updateAvatar
	- implement forgetPassword logic for user reset password
	- implement uploadAvatar logic for user upload image
	- remove unused imports
- EditProfileValidator.java:
	- move uploda image upload validation to UpdateAvatarValidator
	- This logic is still imcomplete
- UpdateUserAvatarRequest.java: dinfine User avatar upload request schema
- EmailService.java : implement logic for sending emails to users via Gmail
- ResetTokenGenerator.java: implement token generation logic
- ForgetPasswordValidator.java: validate if email exists in database
- UpdateAvatarValidator.java: validate image type , name not empty, and length < 255
- pom.xml: add dependency for Gmail email service