### PR TITLE
feat: implement Payment flow and refine registeration flow

### DIFF
--- a/src/main/java/com/example/demo/bean/UserBean.java
+++ b/src/main/java/com/example/demo/bean/UserBean.java
@@ -4,6 +4,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 import com.example.demo.enums.UserRole;
+import com.example.demo.enums.UserStatus;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -54,7 +55,11 @@ public class UserBean {
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private UserRole role;
-    
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private UserStatus status;
+
     @Column(name = "created_at")
     private LocalDateTime createdAt;
     

--- a/src/main/java/com/example/demo/config/SecurityConfig.java
+++ b/src/main/java/com/example/demo/config/SecurityConfig.java
@@ -30,6 +30,7 @@ public class SecurityConfig {
                 .requestMatchers("/users/verify/**").permitAll() // 允許忘記密碼驗證連結
                 .requestMatchers("/products").permitAll()
                 .requestMatchers("/categories").permitAll()
+                .requestMatchers("/payments/**").permitAll()
                 .anyRequest().authenticated()
             )
             .csrf(csrf -> csrf.disable()) // 可選擇關閉 CSRF（特別是 API）

--- a/src/main/java/com/example/demo/controllers/PaymentController.java
+++ b/src/main/java/com/example/demo/controllers/PaymentController.java
@@ -1,0 +1,113 @@
+package com.example.demo.controllers;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.springframework.http.MediaType;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.example.demo.pay.EcpayProps;
+import com.example.demo.pay.EcpaySigner;
+import com.example.demo.pay.PaymentParamsFactory;
+
+@RestController
+@RequestMapping("/payments")
+public class PaymentController {
+    private final PaymentParamsFactory factory;
+    private final EcpayProps props;
+    private final ConcurrentHashMap<String, String> orderStatus = new ConcurrentHashMap<>();
+    private final EcpaySigner signer;
+
+    public PaymentController(PaymentParamsFactory factory, EcpayProps props) {
+        this.factory = factory;
+        this.props = props;
+        this.signer = new EcpaySigner(props.getHashKey(), props.getHashIv());
+    }
+
+    /** 1) 建立訂單並回傳自動提交的 HTML 表單（導到綠界付款頁） */
+
+    @PostMapping(value = "/checkout",produces = MediaType.TEXT_HTML_VALUE)
+    @ResponseBody
+    public String checkout(@RequestParam String orderId, @RequestParam int amount,
+                           @RequestParam(defaultValue = "Demo 商品x1") String itemName, 
+                           @RequestParam(defaultValue = "Demo 訂單")  String tradeDesc) {
+        // 確保 MerchantTradeNo 唯一（可用你的 orderId 加上時間戳或隨機碼）
+        String merchantTradeNo = ensureUniqueTradeNo(orderId);
+        orderStatus.put(merchantTradeNo, "PENDING");
+
+        Map<String, String> form = factory.buildCreditCheckoutParams(
+                merchantTradeNo, amount, itemName, tradeDesc,
+                props.getReturnUrl(), props.getResultUrl());
+
+        // 回傳自動 submit 的 HTML
+        return buildAutoPostHtml(factory.getCheckoutUrl(), form);
+    }
+
+    /** 2) Server 背景通知（ReturnURL） */
+    @PostMapping("/return")
+    @ResponseBody
+    public String serverReturn(@RequestParam MultiValueMap<String, String> body) {
+        Map<String, String> p = flat(body);
+
+        // 驗簽
+        String provided = p.getOrDefault("CheckMacValue", "");
+        String computed = signer.genCheckMacValue(p);
+        boolean ok = provided != null && provided.equalsIgnoreCase(computed);
+
+        if (ok && "1".equals(p.get("RtnCode"))) {
+            String tradeNo = p.get("MerchantTradeNo");
+            if (tradeNo != null) orderStatus.put(tradeNo, "PAID");
+            // 重要：回覆純文字 1|OK
+            return "1|OK";
+        }
+        return "0|ERROR"; // 失敗就不要 1|OK
+    }
+
+    /** 3) Client 導回顯示結果（OrderResultURL） */
+    @PostMapping("/result")
+    @ResponseBody
+    public String clientResult(@RequestParam MultiValueMap<String, String> body) {
+        Map<String, String> p = flat(body);
+        String tradeNo = p.getOrDefault("MerchantTradeNo", "UNKNOWN");
+        String status = orderStatus.getOrDefault(tradeNo, "PENDING");
+        return "<h2>付款結果</h2>"
+                + "<p>MerchantTradeNo: " + tradeNo + "</p>"
+                + "<p>Status: " + status + "</p>"
+                + "<p>RtnMsg: " + p.getOrDefault("RtnMsg", "") + "</p>";
+    }
+
+    // ===== helpers =====
+    private static Map<String, String> flat(MultiValueMap<String, String> mv) {
+        Map<String, String> map = new HashMap<>();
+        for (String k : mv.keySet()) map.put(k, mv.getFirst(k));
+        return map;
+    }
+
+
+    private static String buildAutoPostHtml(String action, Map<String, String> fields) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("<html><body onload='document.forms[0].submit()'>")
+          .append("<form method='post' action='").append(action).append("'>");
+        for (Map.Entry<String, String> e : fields.entrySet()) {
+            sb.append("<input type='hidden' name='").append(e.getKey())
+              .append("' value='").append(escapeHtml(e.getValue())).append("'>");
+        }
+        sb.append("</form><p>Redirecting to ECPay...</p></body></html>");
+        return sb.toString();
+    }
+
+    private static String escapeHtml(String s) {
+        return s.replace("&", "&amp;").replace("<", "&lt;")
+                .replace(">", "&gt;").replace("\"", "&quot;")
+                .replace("'", "&#x27;");
+    }
+    private static String ensureUniqueTradeNo(String orderId) {
+        return (orderId + System.currentTimeMillis()).substring(0, Math.min(20, (orderId + System.currentTimeMillis()).length()));
+    }
+}

--- a/src/main/java/com/example/demo/controllers/UserController.java
+++ b/src/main/java/com/example/demo/controllers/UserController.java
@@ -18,6 +18,7 @@ import org.springframework.web.multipart.MultipartFile;
 import com.example.demo.dto.ForgetPasswordRequest;
 import com.example.demo.dto.LoginRequest;
 import com.example.demo.dto.RegisterRequest;
+import com.example.demo.dto.ResendVerificationEmailRequest;
 import com.example.demo.dto.UpdatePasswordRequest;
 import com.example.demo.dto.UpdateUserAvatarRequqst;
 import com.example.demo.dto.UpdateUserRequest;
@@ -25,7 +26,6 @@ import com.example.demo.responses.ApiResponse;
 import com.example.demo.services.UserService;
 import com.example.demo.utils.VaildationHelper;
 
-import jakarta.transaction.Transactional;
 import jakarta.validation.Valid;
 import lombok.extern.slf4j.Slf4j;
 
@@ -123,5 +123,14 @@ public class UserController {
         ApiResponse response = userService.verifyToken(token);
         return ResponseEntity.ok().body(response);
     }
+
+    @PostMapping("/verify/resend")
+    public ResponseEntity<?> ResendVerificationEmail(@Valid @RequestBody ResendVerificationEmailRequest request, BindingResult result) {
+
+        validationHelper.validateOrThrow(result);
+        ApiResponse response = userService.resendVerificationEmail(request);
+        return ResponseEntity.ok().body(response);
+    }
+    
 
 }

--- a/src/main/java/com/example/demo/dto/PaymentCheckoutRequest.java
+++ b/src/main/java/com/example/demo/dto/PaymentCheckoutRequest.java
@@ -1,0 +1,11 @@
+package com.example.demo.dto;
+
+import lombok.Data;
+
+@Data
+public class PaymentCheckoutRequest {
+    private String orderId;
+    private int amount;
+    private String itemName;
+    private String tradeDesc;
+}

--- a/src/main/java/com/example/demo/dto/ResendVerificationEmailRequest.java
+++ b/src/main/java/com/example/demo/dto/ResendVerificationEmailRequest.java
@@ -1,0 +1,12 @@
+package com.example.demo.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Data;
+
+@Data
+public class ResendVerificationEmailRequest {
+    @NotBlank(message = "Email is required")
+    @Email(message = "Invalid email format")
+    private String email;
+}

--- a/src/main/java/com/example/demo/enums/UserStatus.java
+++ b/src/main/java/com/example/demo/enums/UserStatus.java
@@ -1,0 +1,22 @@
+package com.example.demo.enums;
+
+public enum UserStatus {
+    ACTIVE("active"),
+    INACTIVE("inactive"),
+    BANNED("banned");
+
+    private final String status;
+
+    UserStatus(String status) {
+        this.status = status;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    @Override
+    public String toString() {
+        return status;
+    }
+}

--- a/src/main/java/com/example/demo/pay/EcpayProps.java
+++ b/src/main/java/com/example/demo/pay/EcpayProps.java
@@ -1,0 +1,29 @@
+package com.example.demo.pay;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConfigurationProperties(prefix = "ecpay")
+public class EcpayProps {
+    private String merchantId;
+    private String hashKey;
+    private String hashIv;
+    private String checkoutUrl;
+    private String returnUrl;
+    private String resultUrl;
+
+    // getters & setters ...
+    public String getMerchantId() { return merchantId; }
+    public void setMerchantId(String merchantId) { this.merchantId = merchantId; }
+    public String getHashKey() { return hashKey; }
+    public void setHashKey(String hashKey) { this.hashKey = hashKey; }
+    public String getHashIv() { return hashIv; }
+    public void setHashIv(String hashIv) { this.hashIv = hashIv; }
+    public String getCheckoutUrl() { return checkoutUrl; }
+    public void setCheckoutUrl(String checkoutUrl) { this.checkoutUrl = checkoutUrl; }
+    public String getReturnUrl() { return returnUrl; }
+    public void setReturnUrl(String returnUrl) { this.returnUrl = returnUrl; }
+    public String getResultUrl() { return resultUrl; }
+    public void setResultUrl(String resultUrl) { this.resultUrl = resultUrl; }
+}

--- a/src/main/java/com/example/demo/pay/EcpaySigner.java
+++ b/src/main/java/com/example/demo/pay/EcpaySigner.java
@@ -1,0 +1,67 @@
+package com.example.demo.pay;
+
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.util.Locale;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class EcpaySigner {
+
+    private final String hashKey;
+    private final String hashIV;
+
+    public EcpaySigner(String hashKey, String hashIV) {
+        this.hashKey = hashKey;
+        this.hashIV = hashIV;
+    }
+
+    public String genCheckMacValue(Map<String, String> params) {
+        // 1) 過濾空值與 CheckMacValue 自身
+        Map<String, String> filtered = params.entrySet().stream()
+                .filter(e -> e.getValue() != null && !e.getKey().equalsIgnoreCase("CheckMacValue"))
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+
+        // 2) 以參數名字典序排序（A→Z）
+        String query = filtered.entrySet().stream()
+                .sorted(Map.Entry.comparingByKey(String.CASE_INSENSITIVE_ORDER))
+                .map(e -> e.getKey() + "=" + e.getValue())
+                .collect(Collectors.joining("&"));
+
+        // 3) 前後加入 HashKey / HashIV
+        String raw = "HashKey=" + hashKey + "&" + query + "&HashIV=" + hashIV;
+
+        // 4) URL Encode（UTF-8），轉小寫
+        String encoded = urlEncode(raw).toLowerCase(Locale.ROOT);
+
+        // 5) SHA256 雜湊
+        String sha = sha256(encoded);
+
+        // 6) 轉大寫即為 CheckMacValue
+        return sha.toUpperCase(Locale.ROOT);
+    }
+
+    private static String urlEncode(String s) {
+        // 使用 URLEncoder，並保留 *()!~ 等常見字元的 ECPay 規則差異可先忽略（測試通常可過）
+        return URLEncoder.encode(s, StandardCharsets.UTF_8)
+                .replace("%20", "+")
+                .replace("%21", "!")
+                .replace("%28", "(")
+                .replace("%29", ")")
+                .replace("%2a", "*")
+                .replace("%7e", "~");
+    }
+
+    private static String sha256(String s) {
+        try {
+            MessageDigest md = MessageDigest.getInstance("SHA-256");
+            byte[] out = md.digest(s.getBytes(StandardCharsets.UTF_8));
+            StringBuilder sb = new StringBuilder();
+            for (byte b : out) sb.append(String.format("%02x", b));
+            return sb.toString();
+        } catch (Exception e) {
+            throw new RuntimeException("SHA256 error", e);
+        }
+    }
+}

--- a/src/main/java/com/example/demo/pay/PaymentParamsFactory.java
+++ b/src/main/java/com/example/demo/pay/PaymentParamsFactory.java
@@ -1,0 +1,44 @@
+package com.example.demo.pay;
+
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class PaymentParamsFactory {
+
+    private final EcpayProps props;
+    private final EcpaySigner signer;
+
+    public PaymentParamsFactory(EcpayProps props) {
+        this.props = props;
+        this.signer = new EcpaySigner(props.getHashKey(), props.getHashIv());
+    }
+
+    public Map<String, String> buildCreditCheckoutParams(String tradeNo, int amount, String itemName,
+                                                         String tradeDesc, String returnURL, String resultURL) {
+        Map<String, String> m = new LinkedHashMap<>();
+        m.put("MerchantID", props.getMerchantId());
+        m.put("MerchantTradeNo", tradeNo); // 必須唯一，≤20
+        m.put("MerchantTradeDate", new SimpleDateFormat("yyyy/MM/dd HH:mm:ss").format(new Date()));
+        m.put("PaymentType", "aio");
+        m.put("TotalAmount", String.valueOf(amount)); // 整數
+        m.put("TradeDesc", tradeDesc);                // 送簽前即可（實務可先 URL encode，但這裡交由 signer 統一處理）
+        m.put("ItemName", itemName);                  // 多品名用 # 分隔：蛋糕x1#咖啡x2
+        m.put("ReturnURL", returnURL);                // Server 背景通知
+        m.put("OrderResultURL", resultURL);           // Client 導回顯示頁
+        m.put("ChoosePayment", "Credit");
+        m.put("EncryptType", "1");                    // SHA256
+
+        // 加上 CheckMacValue
+        m.put("CheckMacValue", signer.genCheckMacValue(m));
+        return m;
+    }
+
+    public String getCheckoutUrl() {
+        return props.getCheckoutUrl();
+    }
+}

--- a/src/main/java/com/example/demo/services/TokenService.java
+++ b/src/main/java/com/example/demo/services/TokenService.java
@@ -29,9 +29,9 @@ public class TokenService {
     private EntityManager em;
 
     @Transactional
-    public String generateToken(Long userId){
+    public String generateToken(Long userId, TokenType tokenType){
 
-        TokenBean existingToken = tokenRepository.findByUserIdAndTokenType(userId, TokenType.forgetPassword);
+        TokenBean existingToken = tokenRepository.findByUserIdAndTokenType(userId, tokenType);
         if (existingToken != null && !existingToken.isUsed()) {
             // 如果已存在且未使用，則返回已存在的 token
             return existingToken.getToken();
@@ -43,7 +43,7 @@ public class TokenService {
         TokenBean tokenBean = new TokenBean();
         tokenBean.setUser(em.getReference(UserBean.class, userId));
         tokenBean.setToken(token);
-        tokenBean.setTokenType(TokenType.forgetPassword);
+        tokenBean.setTokenType(tokenType);
         tokenBean.setUsed(false);
         tokenBean.setCreatedAt(LocalDateTime.now());
         tokenBean.setExpiresAt(expiresAt);

--- a/src/main/java/com/example/demo/vaildator/ResendVerificationEmailValidator.java
+++ b/src/main/java/com/example/demo/vaildator/ResendVerificationEmailValidator.java
@@ -1,0 +1,40 @@
+package com.example.demo.vaildator;
+
+import java.util.Optional;
+
+import org.springframework.stereotype.Component;
+
+import com.example.demo.bean.UserBean;
+import com.example.demo.dto.ErrorInfo;
+import com.example.demo.dto.ResendVerificationEmailRequest;
+import com.example.demo.exception.ApiException;
+import com.example.demo.repository.UserRepository;
+
+@Component
+public class ResendVerificationEmailValidator implements CustValidator<ResendVerificationEmailRequest, UserBean> {
+
+    private final UserRepository userRepository;
+    private ResendVerificationEmailValidator(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    @Override
+    public boolean support(Class<?> clazz) {
+        return ResendVerificationEmailRequest.class.isAssignableFrom(clazz);
+    }
+
+    @Override
+    public UserBean validate(ResendVerificationEmailRequest request) {
+        Optional<UserBean> userOptional = userRepository.findByEmail(request.getEmail());
+        UserBean user = userOptional.orElseThrow(() -> {
+            ErrorInfo errorInfo = new ErrorInfo();
+            errorInfo.addError("email", "email not found");
+            throw new ApiException("email not found", 400, errorInfo);
+        });
+
+        return user;
+    }
+
+
+
+}


### PR DESCRIPTION
## Change Made:

### Implement Payment Flow
- PaymentController:
  - add POST /payments/chekout endpoint to create orders via ECPay API
  - add POST /payments/return endpoint to handle ECPay server callbacks
  - add POST /payments/result endpoint to handle payment completion redirects
  - add buildAutoPostHtml method to generate HTML form and redirect to ECPay payment page
  - add flat method to convert between MultiVlaueMap and Map
  - add escapeHTML method to escape HTML entities
  - add ensureUniqueTradeNo to generate unique order IDs
- EcpayProps: bind essential ECPay API parameter s from YAML config
- PaymentParamsFactory: build paramters required for order creation
- EcpaySigner: generate CheckMacValue per ECPay encryption rules
- PaymentCheckoutRequest: define request parameters for order creation
- SecurityConfig: 新增 "/payments/" requestMatchers for payment integration testing
- ecommerce-docs: update sub-repository to latest version

### Refine Registeration Flow
- UserBean: add status field to manage user lifecycle (ACTIVE, INACTIVE, BANNED)
- UserController: add POST /users/verify/resend for resending verification emails
- UserService: 
  - set new users to INACTIVE and send verification email on signup
  - include TokenType in forget-passowrd flow to align with TokenService
  - activate user (status=ACTIVE) upon success email 
  - implement resend verification email logic
- UserStatus: introduce enum for user status
- TokenServer: accept TokenType to unify logic across forget-password and email-verification flow
- ResendVerificationEmailValidator: add validator for resend verification email to ensure email exists in database
- ResendVerificationEmailRequest: define request parameters fro resneding verification emails